### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 cache: yarn
 node_js:
   - node
-  - "9"
+  - "10"
   - "8"
   - "6"
 git:


### PR DESCRIPTION
Node.js has reached its EOL (never use an odd release branch). We should test 10 LTS.