### PR TITLE
clearPackageJSON do not remove scripts when indicating explicitly

### DIFF
--- a/core.js
+++ b/core.js
@@ -37,10 +37,12 @@ function clearPackageJSON (packageJson, inputIgnoreFields) {
   const clearedScripts = {
     scripts: pick(NPM_SCRIPTS, packageJson.scripts)
   }
-  const cleanPackageJSON = Object.assign(
-    omit(ignoreFields, packageJson),
+  const cleanPackageJSON = omit(ignoreFields, Object.assign(
+    {},
+    packageJson,
     clearedScripts
-  )
+  ))
+
   for (const i in cleanPackageJSON) {
     if (typeof cleanPackageJSON[i] === 'object') {
       if (Object.keys(cleanPackageJSON[i]).length === 0) {


### PR DESCRIPTION
Run:
```sh
npx clean-publish --without-publish --fields scripts
```

Result (package.json):
```json
{ 
    "scripts": {
         "prepublish" : "кукусики"
    }
}
```