### PR TITLE
Remove `prepublishOnly` from npm scripts

### DIFF
--- a/exception/npm-scripts.js
+++ b/exception/npm-scripts.js
@@ -3,7 +3,6 @@ module.exports = [
   'postversion',
   'postpack',
   'prepublish',
-  'prepublishOnly',
   'publish',
   'postpublish',
   'postinstall'


### PR DESCRIPTION
> prepublishOnly: Run BEFORE the package is prepared and packed, ONLY on npm publish. (See below.)

https://docs.npmjs.com/misc/scripts

So it is mean that `prepublishOnly` do not need on npm 