### PR TITLE
Allow to use tool in projects without scripts

### DIFF
--- a/core.js
+++ b/core.js
@@ -35,8 +35,11 @@ function clearPackageJSON (packageJson, inputIgnoreFields) {
   const ignoreFields = inputIgnoreFields
     ? IGNORE_FIELDS.concat(inputIgnoreFields)
     : IGNORE_FIELDS
-  const clearedScripts = {
-    scripts: pick(NPM_SCRIPTS, packageJson.scripts)
+  let clearedScripts = { }
+  if (packageJson.scripts) {
+    clearedScripts = {
+      scripts: pick(NPM_SCRIPTS, packageJson.scripts)
+    }
   }
   const cleanPackageJSON = omit(ignoreFields, Object.assign(
     {},


### PR DESCRIPTION
I found the problem when I tried to test `clean-publish` inside Size Limit fixtures.

I think script-less project is pretty real case.