### PR TITLE
Add EditorConfig to force UNIX newline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Possible solution #73 (but I am not sure). WebStorm supports it out of the box and VS Code has [a plugin](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig).

You may need to re-save all fixes to force a new EOL.