### PR TITLE
Clean up dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 cache: yarn
 node_js:
   - node
+  - "14"
+  - "12"
   - "10"
-  - "8"
-  - "6"
-git:
-  depth: 5

--- a/clean-publish.js
+++ b/clean-publish.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const yargs = require('yargs')
 const {
   createTempDirectory,
   readSrcDirectory,
@@ -15,44 +14,54 @@ const {
 } = require('./core')
 const getConfig = require('./get-config')
 
-const { argv } = yargs
-  .usage('$0')
-  .option('files', {
-    type: 'array',
-    desc: 'One or more exclude files'
-  })
-  .option('fields', {
-    type: 'array',
-    desc: 'One or more exclude package.json fields'
-  })
-  .option('without-publish', {
-    type: 'boolean',
-    desc: 'Clean package without npm publish'
-  })
-  .option('package-manager', {
-    types: 'string',
-    default: 'npm',
-    desc: 'Package manager to use'
-  })
-  .option('access', {
-    types: 'string',
-    desc: 'Whether the npm registry publishes ' +
-      'this package as a public package, or restricted'
-  })
-  .option('before-script', {
-    types: 'string',
-    desc: 'Run script on the to-release dir before npm publish'
-  })
+const HELP = 'npx clean-publish\n' +
+  '\n' +
+  'Options:\n' +
+  '  --help             Show help\n' +
+  '  --version          Show version number\n' +
+  '  --files            One or more exclude files\n' +
+  '  --fields           One or more exclude package.json fields\n' +
+  '  --without-publish  Clean package without npm publish\n' +
+  '  --package-manager  Package manager to use\n' +
+  '  --access           Whether the npm registry publishes this package\n' +
+  '                     as a public package, or restricted\n' +
+  '  --before-script    Run script on the to-release dir before npm\n' +
+  '                     publish'
 
 const options = {}
 let tempDirectoryName
 
 function handleOptions () {
-  Object.assign(options, argv, {
-    withoutPublish: argv['without-publish'],
-    packageManager: argv['package-manager']
-  })
-  if (options['_'].length === 0) {
+  options.packageManager = 'npm'
+  for (let i = 2; i < process.argv.length; i++) {
+    if (process.argv[i] === '--help') {
+      console.log(HELP)
+      process.exit(0)
+    } else if (process.argv[i] === '--version') {
+      console.log(require('./package.json').version)
+      process.exit(0)
+    } else if (process.argv[i] === '--without-publish') {
+      options.withoutPublish = true
+    } else if (process.argv[i] === '--package-manager') {
+      options.packageManager = process.argv[i + 1]
+      i += 1
+    } else if (process.argv[i] === '--before-script') {
+      options.beforeScript = process.argv[i + 1]
+      i += 1
+    } else if (process.argv[i] === '--access') {
+      options.access = process.argv[i + 1]
+      i += 1
+    } else if (process.argv[i] === '--files') {
+      options.files = process.argv[i + 1].split(/,\s*/)
+      i += 1
+    } else if (process.argv[i] === '--fields') {
+      options.fields = process.argv[i + 1].split(/,\s*/)
+      i += 1
+    } else {
+      options['_'] = process.argv[i]
+    }
+  }
+  if (!options['_']) {
     return getConfig().then(config => {
       Object.assign(options, config)
     })

--- a/clean-publish.js
+++ b/clean-publish.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const chalk = require('chalk')
 const yargs = require('yargs')
 const {
   createTempDirectory,
@@ -101,6 +100,6 @@ handleOptions()
     }
   })
   .catch(error => {
-    console.error(chalk.red(error))
+    console.error(error)
     process.exit(1)
   })

--- a/clear-package-json.js
+++ b/clear-package-json.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const chalk = require('chalk')
 const yargs = require('yargs')
 const {
   clearPackageJSON
@@ -72,6 +71,6 @@ handleOptions()
     process.stdout.write(`${ JSON.stringify(cleanPackageJSON, null, '  ') }\n`)
   })
   .catch(error => {
-    console.error(chalk.red(error))
+    console.error(error)
     process.exit()
   })

--- a/clear-package-json.js
+++ b/clear-package-json.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const yargs = require('yargs')
 const {
   clearPackageJSON
 } = require('./core')
@@ -12,39 +11,41 @@ const {
 const getConfig = require('./get-config')
 
 const { isTTY } = process.stdin
-const { argv } = yargs
-  .usage('$0')
-  .command(
-    isTTY
-      ? '$0 <input> [options]'
-      : '$0 [options]',
-    'Clear package.json file',
-    yargsCommand => {
-      if (isTTY) {
-        yargsCommand
-          .positional('input', {
-            type: 'string',
-            desc: 'Input package.json file'
-          })
-          .require('input')
-      }
-    }
-  )
-  .option('fields', {
-    type: 'array',
-    desc: 'One or more exclude package.json fields'
-  })
-  .option('output', {
-    alias: 'o',
-    type: 'string',
-    desc: 'Output file name'
-  })
 
-const options = {
-  fields: argv.fields
-}
+const HELP = 'npx clear-package-json <input> [options]\n' +
+  '\n' +
+  'Options:\n' +
+  '  --help        Show help\n' +
+  '  --version     Show version number\n' +
+  '  --fields      One or more exclude package.json fields\n' +
+  '  --output, -o  Output file name'
+
+const options = {}
+let input, output
 
 function handleOptions () {
+  for (let i = 2; i < process.argv.length; i++) {
+    if (process.argv[i] === '--help') {
+      console.log(HELP)
+      process.exit(0)
+    } else if (process.argv[i] === '--version') {
+      console.log(require('./package.json').version)
+      process.exit(0)
+    } else if (process.argv[i] === '-o' || process.argv[i] === '--output') {
+      output = process.argv[i + 1]
+      i += 1
+    } else if (process.argv[i] === '--fields') {
+      options.fields = process.argv[i + 1].split(/,\s*/)
+      i += 1
+    } else {
+      input = process.argv[i]
+    }
+  }
+  if (!input) {
+    console.log(HELP)
+    console.error('\nNot enough non-option arguments: got 0, need at least 1')
+    process.exit(1)
+  }
   if (!options.fields) {
     return getConfig().then(config => {
       options.fields = config.fields
@@ -56,14 +57,14 @@ function handleOptions () {
 handleOptions()
   .then(() => (
     isTTY
-      ? readJson(argv.input)
+      ? readJson(input)
       : readJsonFromStdin()
   ))
   .then(packageJson => {
     const cleanPackageJSON = clearPackageJSON(packageJson, options.fields)
-    if (argv.output) {
+    if (output) {
       return writeJson(
-        argv.output,
+        output,
         cleanPackageJSON,
         { spaces: 2 }
       )

--- a/core.js
+++ b/core.js
@@ -1,10 +1,6 @@
 const path = require('path')
 const spawn = require('cross-spawn')
 const {
-  omit,
-  pick
-} = require('ramda')
-const {
   regExpIndexOf,
   multiCp,
   writeJson,
@@ -34,17 +30,20 @@ function clearPackageJSON (packageJson, inputIgnoreFields) {
   const ignoreFields = inputIgnoreFields
     ? IGNORE_FIELDS.concat(inputIgnoreFields)
     : IGNORE_FIELDS
-  let clearedScripts = { }
-  if (packageJson.scripts) {
-    clearedScripts = {
-      scripts: pick(NPM_SCRIPTS, packageJson.scripts)
+  const cleanPackageJSON = {}
+  for (const key in packageJson) {
+    if (!ignoreFields.includes(key) && key !== 'scripts') {
+      cleanPackageJSON[key] = packageJson[key]
     }
   }
-  const cleanPackageJSON = omit(ignoreFields, Object.assign(
-    {},
-    packageJson,
-    clearedScripts
-  ))
+  if (packageJson.scripts && !ignoreFields.includes('scripts')) {
+    cleanPackageJSON.scripts = {}
+    for (const script in packageJson.scripts) {
+      if (NPM_SCRIPTS.includes(script)) {
+        cleanPackageJSON.scripts[script] = packageJson.scripts[script]
+      }
+    }
+  }
 
   for (const i in cleanPackageJSON) {
     if (typeof cleanPackageJSON[i] === 'object') {

--- a/get-config.js
+++ b/get-config.js
@@ -4,7 +4,7 @@
  */
 
 const path = require('path')
-const cosmiconfig = require('cosmiconfig')
+const { lilconfig } = require('lilconfig')
 
 const PACKAGE_ERRORS = {
   notObject: 'The `"clean-publish"` section of package.json ' +
@@ -75,7 +75,7 @@ function configError (config) {
 }
 
 function getConfig () {
-  const explorer = cosmiconfig('clean-publish', {
+  const explorer = lilconfig('clean-publish', {
     searchPlaces: [
       'package.json',
       '.clean-publish',

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "cosmiconfig": "^5.0.7",
     "cross-spawn": "^6.0.5",
     "fs-extra": "^6.0.1",
-    "ramda": "^0.25.0",
-    "yargs": "^12.0.1"
+    "ramda": "^0.25.0"
   },
   "devDependencies": {
     "eslint": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clear-package-json": "clear-package-json.js"
   },
   "engines": {
-    "node": ">=6.11.5"
+    "node": ">=10.0"
   },
   "dependencies": {
     "chalk": "^2.4.1",
@@ -24,7 +24,6 @@
     "cross-spawn": "^6.0.5",
     "fs-extra": "^6.0.1",
     "ramda": "^0.25.0",
-    "util.promisify": "^1.0.0",
     "yargs": "^12.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "node": ">=10.0"
   },
   "dependencies": {
-    "cross-spawn": "^6.0.5",
-    "fs-extra": "^6.0.1",
+    "cross-spawn": "^7.0.3",
+    "fs-extra": "^9.1.0",
     "lilconfig": "^2.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "node": ">=10.0"
   },
   "dependencies": {
-    "chalk": "^2.4.1",
     "cosmiconfig": "^5.0.7",
     "cross-spawn": "^6.0.5",
     "fs-extra": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "cross-spawn": "^6.0.5",
     "fs-extra": "^6.0.1",
-    "lilconfig": "^2.0.2",
-    "ramda": "^0.25.0"
+    "lilconfig": "^2.0.2"
   },
   "devDependencies": {
     "eslint": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "node": ">=10.0"
   },
   "dependencies": {
-    "cosmiconfig": "^5.0.7",
     "cross-spawn": "^6.0.5",
     "fs-extra": "^6.0.1",
+    "lilconfig": "^2.0.2",
     "ramda": "^0.25.0"
   },
   "devDependencies": {

--- a/utils.js
+++ b/utils.js
@@ -1,4 +1,4 @@
-const promisify = require('util.promisify/polyfill')()
+const { promisify } = require('util')
 const fs = require('fs')
 const fse = require('fs-extra')
 

--- a/utils.js
+++ b/utils.js
@@ -1,13 +1,5 @@
-const { promisify } = require('util')
-const fs = require('fs')
-const fse = require('fs-extra')
-
-const mkdtemp = promisify(fs.mkdtemp)
-const readdir = promisify(fs.readdir)
-const copy = fse.copy
-const remove = fse.remove
-const readJson = fse.readJson
-const writeJson = fse.writeJson
+const { mkdtemp, readdir } = require('fs').promises
+const { copy, remove, readJson, writeJson } = require('fs-extra')
 
 function regExpIndexOf (array, item) {
   for (const i in array) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,6 +222,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
@@ -707,6 +712,15 @@ cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.4"
@@ -1328,13 +1342,15 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fs-extra@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
+fs-extra@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
   dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-minipass@^1.2.5:
   version "1.2.5"
@@ -1442,6 +1458,11 @@ globby@^5.0.0:
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+graceful-fs@^4.2.0:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
+  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -2314,9 +2335,12 @@ json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -2989,6 +3013,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
@@ -3434,9 +3463,21 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -3863,9 +3904,10 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^0.4.3"
 
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unset-value@^1.0.0:
   version "1.0.0"
@@ -3975,6 +4017,13 @@ which@1.2.x:
 which@^1.2.10, which@^1.2.12, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -532,7 +532,7 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3121,10 +3121,6 @@ qs@~6.5.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
-ramda@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
-
 randomatic@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.0.0.tgz#d35490030eb4f7578de292ce6dfb04a91a128923"

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,12 +775,7 @@ debug@^3.1.0:
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-
-decamelize@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-2.0.0.tgz#656d7bbc8094c4c788ea53c5840908c9c7d063c7"
-  dependencies:
-    xregexp "4.0.0"
+  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -1315,12 +1310,6 @@ find-up@^2.0.0, find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
-
-find-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
-  dependencies:
-    locate-path "^3.0.0"
 
 flat-cache@^1.2.1:
   version "1.3.0"
@@ -2518,13 +2507,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-locate-path@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
-  dependencies:
-    p-locate "^3.0.0"
-    path-exists "^3.0.0"
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -2890,6 +2872,7 @@ object.pick@^1.3.0:
 once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
 
@@ -2967,23 +2950,11 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
-  dependencies:
-    p-try "^2.0.0"
-
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
-
-p-locate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
-  dependencies:
-    p-limit "^2.0.0"
 
 p-map@^1.1.1:
   version "1.2.0"
@@ -2992,10 +2963,6 @@ p-map@^1.1.1:
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-
-p-try@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -4100,17 +4067,9 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
-xregexp@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
-
 y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-
-"y18n@^3.2.1 || ^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
 
 yallist@^2.1.2:
   version "2.1.2"
@@ -4119,12 +4078,6 @@ yallist@^2.1.2:
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
-
-yargs-parser@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
-  dependencies:
-    camelcase "^4.1.0"
 
 yargs-parser@^9.0.2:
   version "9.0.2"
@@ -4148,23 +4101,6 @@ yargs@^11.0.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
-
-yargs@^12.0.1:
-  version "12.0.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.1.tgz#6432e56123bb4e7c3562115401e98374060261c2"
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^2.0.0"
-    find-up "^3.0.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1 || ^4.0.0"
-    yargs-parser "^10.1.0"
 
 yargs@~3.10.0:
   version "3.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,25 +469,11 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-caller-callsite@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
-  integrity sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
-  dependencies:
-    callsites "^2.0.0"
-
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
   dependencies:
     callsites "^0.2.0"
-
-caller-path@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
-  integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
-  dependencies:
-    caller-callsite "^2.0.0"
 
 callsites@^0.2.0:
   version "0.2.0"
@@ -700,16 +686,6 @@ cosmiconfig@^5.0.2:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
   dependencies:
-    is-directory "^0.3.1"
-    js-yaml "^3.9.0"
-    parse-json "^4.0.0"
-
-cosmiconfig@^5.0.7:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.7.tgz#39826b292ee0d78eda137dfa3173bd1c21a43b04"
-  integrity sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==
-  dependencies:
-    import-fresh "^2.0.0"
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
@@ -1592,14 +1568,6 @@ ignore@^3.3.3, ignore@^3.3.6:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
-import-fresh@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
-  integrity sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
-  dependencies:
-    caller-path "^2.0.0"
-    resolve-from "^3.0.0"
-
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
@@ -2405,6 +2373,11 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lilconfig@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.2.tgz#9f802752254697d22a5c33e88d97b7329008c060"
+  integrity sha512-4zUThttj8TQ4N7Pps92Z79jPf1OMcll4m61pivQSVk5MT78hVhNa2LrKTuNYD0AGLpmpf7zeIKOxSt6hHBfypw==
 
 lint-staged@^7.2.0:
   version "7.2.0"


### PR DESCRIPTION
I reduced project dependencies.

Fixes #72.

In addition to reducing the `node_modules` size, it will reduce the number of dependabot PRs.

The side effect, that it bumps the minimal Node.js version, so it will require a major release. But most npm packages already require Node.js >= 10.