### PR TITLE
Add uninstall script to exceptions

### DIFF
--- a/exception/npm-scripts.js
+++ b/exception/npm-scripts.js
@@ -5,5 +5,6 @@ module.exports = [
   'prepublish',
   'publish',
   'postpublish',
-  'postinstall'
+  'postinstall',
+  'uninstall'
 ]


### PR DESCRIPTION
Some packages require `uninstall` script to work correctly. 

E.g [simple-git-hooks](https://github.com/toplenboren/simple-git-hooks) which has uninstall script to remove all git hooks on uninstallation:

`package.json >`

``` json
"scripts": {
    "postinstall": "node ./postinstall.js",
    "lint": "eslint *.js",
    "test": "jest",
    "publish": "clean-publish",
    "uninstall": "node ./uninstall.js"
  },
```
