### PR TITLE
clean-docs: handle packageJson.repository object

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "cross-spawn": "^7.0.3",
     "fast-glob": "^3.2.7",
     "fs-extra": "^10.0.0",
+    "hosted-git-info": "^4.0.2",
     "lilconfig": "^2.0.3"
   },
   "devDependencies": {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -2,7 +2,7 @@ import fse from 'fs-extra'
 import { join } from 'path'
 import { fileURLToPath } from 'url'
 
-import { clearPackageJSON } from '../core.js'
+import { clearPackageJSON, getReadmeUrlFromRepository } from '../core.js'
 
 const dirname = join(fileURLToPath(import.meta.url), '..')
 const srcPackageJSONPath = join(dirname, 'package', 'package.json')
@@ -53,5 +53,25 @@ describe('clearPackageJSON', () => {
     }
 
     expect(clearPackageJSON(packageJson, [], ['development'])).toEqual(expected)
+  })
+})
+
+describe('getReadmeUrlFromRepository', () => {
+  const git = 'https://github.com/org/repo.git'
+  const shirtcut = 'org/repo'
+  const bitbucketShirtcut = 'bitbucket:org/repo'
+  const readme = 'https://github.com/org/repo#readme'
+  const bitbucketReadme = 'https://bitbucket.org/org/repo#readme'
+
+  it('should return docs url', () => {
+    expect(getReadmeUrlFromRepository(git)).toBe(readme)
+    expect(getReadmeUrlFromRepository(shirtcut)).toBe(readme)
+    expect(getReadmeUrlFromRepository(bitbucketShirtcut)).toBe(bitbucketReadme)
+  })
+
+  it('should handle repo object', () => {
+    expect(getReadmeUrlFromRepository({
+      url: git
+    })).toBe(readme)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,6 +1910,13 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
+hosted-git-info@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.0.2.tgz#5e425507eede4fea846b7262f0838456c4209961"
+  integrity sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==
+  dependencies:
+    lru-cache "^6.0.0"
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"


### PR DESCRIPTION
also [`hosted-git-info`](https://www.npmjs.com/package/hosted-git-info) dependency is added to support [all formats of repository field](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository)