### PR TITLE
Remove 'publish' script if it's 'clean-publish'

### DIFF
--- a/core.js
+++ b/core.js
@@ -46,6 +46,14 @@ export function clearPackageJSON(
     cleanPackageJSON.scripts = filterObjectByKey(packageJson.scripts, script =>
       NPM_SCRIPTS.includes(script)
     )
+
+    if (
+      cleanPackageJSON.scripts.publish &&
+      cleanPackageJSON.scripts.publish.startsWith('clean-publish')
+    ) {
+      // "custom" publish script is actually calling clean-publish
+      delete cleanPackageJSON.scripts.publish
+    }
   }
 
   if (isObject(packageJson.exports) && !ignoreFields.includes('exports')) {

--- a/core.js
+++ b/core.js
@@ -49,7 +49,8 @@ export function clearPackageJSON(
 
     if (
       cleanPackageJSON.scripts.publish &&
-      cleanPackageJSON.scripts.publish.startsWith('clean-publish')
+      (cleanPackageJSON.scripts.publish === 'clean-publish' ||
+        cleanPackageJSON.scripts.publish.startsWith('clean-publish '))
     ) {
       // "custom" publish script is actually calling clean-publish
       delete cleanPackageJSON.scripts.publish


### PR DESCRIPTION
If someone would try setting up 'clean-publish' as told in the docs,
one would get an endless loop when trying to call 'npm publish'. This
is because 'publish' scripts were not removed but called after cleanup,
which would then cause the program to loop endlessly and creates an
infinite tree of temporary directories.

After this commit, 'clean-publish' will check if the 'publish' script
contains call to 'clean-publish' and, if that's the case, remove this
script.

Closes #134
