### PR TITLE
feat: apply and clean publishConfig in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ $ yarn add clean-publish --dev
 - `clean-comments` - clean inline comments from JS files.
 - `files` - list of files that you want to delete before publishing
 - `fields` - list of fields in the `package.json` file that you want to delete before publishing
-- `exports` - list of [exports conditions](https://nodejs.org/api/packages.html#packages_conditional_exports) in the `package.json` file that you want to delete before publishing
 - `without-publish` - clean project without `npm publish` (tmp directory will not be deleted automatically)
 - `package-manager` - name of package manager to use (`npm` by default)
 - `access` - whether the npm registry publishes this package as a public package, or restricted
@@ -193,6 +192,35 @@ Clean Publish also supports 3 ways to define config.
 module.exports = {
   "files": ["file1.js", "file2.js"],
   "packageManager": "yarn"
+}
+```
+
+## Publish config
+
+All package managers have different support of [`publishConfig` filed in package.json](https://github.com/stereobooster/package.json#publishconfig). `clean-publish` handles this field like [pnpm does](https://pnpm.io/ru/package_json#publishconfig) but also cleans and removes it from package.json if possible.
+
+- Before clean:
+
+```json
+{
+  "main": "./src/index.ts",
+  "publishConfig": {
+    "main": "./dist/index.cjs",
+    "module": "./dist/index.js",
+    "directory": "package"
+  }
+}
+```
+
+- After clean:
+
+```json
+{
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "publishConfig": {
+    "directory": "package"
+  }
 }
 ```
 

--- a/clean-publish.js
+++ b/clean-publish.js
@@ -27,7 +27,6 @@ const HELP =
   '  --clean-comments   Clean inline comments from JS files' +
   '  --files            One or more exclude files\n' +
   '  --fields           One or more exclude package.json fields\n' +
-  '  --exports          One or more exclude exports conditions\n' +
   '  --without-publish  Clean package without npm publish\n' +
   '  --dry-run          Reports the details of what would have been published\n' +
   '  --package-manager  Package manager to use\n' +
@@ -80,9 +79,6 @@ async function handleOptions() {
     } else if (process.argv[i] === '--fields') {
       options.fields = parseListArg(process.argv[i + 1])
       i += 1
-    } else if (process.argv[i] === '--exports') {
-      options.exports = parseListArg(process.argv[i + 1])
-      i += 1
     } else if (process.argv[i] === '--temp-dir') {
       options.tempDir = process.argv[i + 1]
       i += 1
@@ -121,11 +117,7 @@ async function run() {
     await cleanComments(tempDirectoryName)
   }
 
-  const cleanPackageJSON = clearPackageJSON(
-    packageJson,
-    options.fields,
-    options.exports
-  )
+  const cleanPackageJSON = clearPackageJSON(packageJson, options.fields)
   await writePackageJSON(tempDirectoryName, cleanPackageJSON)
 
   let prepublishSuccess = true

--- a/clear-package-json.js
+++ b/clear-package-json.js
@@ -16,7 +16,6 @@ const HELP =
   '  --help        Show help\n' +
   '  --version     Show version number\n' +
   '  --fields      One or more exclude package.json fields\n' +
-  '  --exports     One or more exclude exports conditions\n' +
   '  --output, -o  Output file name'
 
 async function handleOptions() {
@@ -36,9 +35,6 @@ async function handleOptions() {
     } else if (process.argv[i] === '--fields') {
       options.fields = parseListArg(process.argv[i + 1])
       i += 1
-    } else if (process.argv[i] === '--exports') {
-      options.exports = parseListArg(process.argv[i + 1])
-      i += 1
     } else {
       input = process.argv[i]
     }
@@ -51,10 +47,9 @@ async function handleOptions() {
     process.exit(1)
   }
 
-  if (!options.fields && !options.exports) {
+  if (!options.fields) {
     let config = await getConfig()
     options.fields = config.fields
-    options.exports = config.exports
   }
   return [input, output, options]
 }
@@ -62,11 +57,7 @@ async function handleOptions() {
 async function run() {
   const [input, output, options] = await handleOptions()
   const packageJson = await (input ? readJson(input) : readJsonFromStdin())
-  const cleanPackageJSON = clearPackageJSON(
-    packageJson,
-    options.fields,
-    options.exports
-  )
+  const cleanPackageJSON = clearPackageJSON(packageJson, options.fields)
   if (output) {
     await writeJson(output, cleanPackageJSON, { spaces: 2 })
   } else {

--- a/get-config.js
+++ b/get-config.js
@@ -19,9 +19,6 @@ const PACKAGE_ERRORS = {
   fieldsNotStrings:
     'The `fields` in the `"clean-publish"` section ' +
     'of package.json must be `an array of strings`',
-  exportsNotStrings:
-    'The `exports` in the `"clean-publish"` section ' +
-    'of package.json must be `an array of strings`',
   tempDirNotString:
     'The `temp-dir` in the `"clean-publish"` section ' +
     'of package.json must be `an string`'
@@ -34,8 +31,6 @@ const FILE_ERRORS = {
     'must be `an array of strings or RegExps`',
   fieldsNotStrings:
     'The `fields` in Clean Publish config ' + 'must be `an array of strings`',
-  exportsNotStrings:
-    'The `exports` in Clean Publish config ' + 'must be `an array of strings`',
   tempDirNotString:
     'The `temp-dir` in Clean Publish config ' + 'must be `an string`'
 }
@@ -95,9 +90,6 @@ function configError(config) {
   }
   if (!isStringsOrUndefined(config.fields)) {
     return 'fieldsNotStrings'
-  }
-  if (!isStringsOrUndefined(config.exports)) {
-    return 'exportsNotStrings'
   }
   if (!isStringOrUndefined(config.tempDir)) {
     return 'tempDirNotString'

--- a/test/clean-package.json
+++ b/test/clean-package.json
@@ -17,10 +17,5 @@
     "url": "https://opencollective.com/jest",
     "logo": "https://opencollective.com/jest/logo.txt"
   },
-  "exports": {
-    ".": {
-      "development": "./src/index.js",
-      "default": "./dist/index.js"
-    }
-  }
+  "exports": "./dist/index.js"
 }

--- a/test/clean-publish-config.json
+++ b/test/clean-publish-config.json
@@ -1,4 +1,3 @@
 {
-  "fields": ["collective"],
-  "exports": ["development"]
+  "fields": ["collective"]
 }

--- a/test/clean-publish.test.js
+++ b/test/clean-publish.test.js
@@ -69,28 +69,6 @@ test('clean-publish function without "npm publish"', async () => {
   await fse.remove(tmpDirPath)
 })
 
-test('clean-publish to omit exports', async () => {
-  await spawn(binPath, ['--without-publish', '--exports', 'development'], {
-    cwd: packagePath
-  })
-
-  const tmpDirPath = await findTmpDir(packagePath)
-  const packageJSONPath = join(tmpDirPath, 'package.json')
-  const obj = await fse.readJSON(packageJSONPath)
-  const cleanerPackageJSON = {
-    ...cleanPackageJSON,
-    exports: {
-      '.': {
-        default: cleanPackageJSON.exports['.'].default
-      }
-    }
-  }
-
-  equal(obj, cleanerPackageJSON)
-
-  await fse.remove(tmpDirPath)
-})
-
 test('clean-publish to make `temp-dir` directory', async () => {
   await spawn(binPath, ['--without-publish', '--temp-dir', tempDir], {
     cwd: packagePath
@@ -140,14 +118,7 @@ test('clean-publish to get config from file', async () => {
   const tmpDirPath = await findTmpDir(packagePath)
   const packageJSONPath = join(tmpDirPath, 'package.json')
   const obj = await fse.readJSON(packageJSONPath)
-  const cleanerPackageJSON = {
-    ...cleanPackageJSON,
-    exports: {
-      '.': {
-        default: cleanPackageJSON.exports['.'].default
-      }
-    }
-  }
+  const cleanerPackageJSON = { ...cleanPackageJSON }
   delete cleanerPackageJSON.collective
 
   equal(obj, cleanerPackageJSON)

--- a/test/clear-package-json.test.js
+++ b/test/clear-package-json.test.js
@@ -47,30 +47,6 @@ test('clear-package-json function', async () => {
   await fse.remove(minPackageJSONPath)
 })
 
-test('clear-package-json to omit exports', async () => {
-  await spawn(
-    binPath,
-    [packageJSONPath, '-o', minPackageJSONPath, '--exports', 'development'],
-    {
-      cwd: packagePath
-    }
-  )
-
-  const obj = await fse.readJSON(minPackageJSONPath)
-  const cleanerPackageJSON = {
-    ...cleanPackageJSON,
-    exports: {
-      '.': {
-        default: cleanPackageJSON.exports['.'].default
-      }
-    }
-  }
-
-  equal(obj, cleanerPackageJSON)
-
-  await fse.remove(minPackageJSONPath)
-})
-
 test('clear-package-json to get fields from config file', async () => {
   await fse.writeFile(
     cleanPublishConfigPath,
@@ -82,14 +58,7 @@ test('clear-package-json to get fields from config file', async () => {
   })
 
   const obj = await fse.readJSON(minPackageJSONPath)
-  const cleanerPackageJSON = {
-    ...cleanPackageJSON,
-    exports: {
-      '.': {
-        default: cleanPackageJSON.exports['.'].default
-      }
-    }
-  }
+  const cleanerPackageJSON = { ...cleanPackageJSON }
   delete cleanerPackageJSON.collective
 
   equal(obj, cleanerPackageJSON)

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -34,28 +34,6 @@ test('clearPackageJSON cleans additional fields', () => {
   equal(clearPackageJSON(srcPackageJson, ['collective']), expected)
 })
 
-test('clearPackageJSON cleans exports', () => {
-  const packageJson = {
-    ...srcPackageJson,
-    exports: {
-      '.': {
-        development: './src/index.js',
-        default: './dest/index.js'
-      }
-    }
-  }
-  const expected = {
-    ...cleanPackageJson,
-    exports: {
-      '.': {
-        default: './dest/index.js'
-      }
-    }
-  }
-
-  equal(clearPackageJSON(packageJson, [], ['development']), expected)
-})
-
 const git = 'https://github.com/org/repo.git'
 const shortcut = 'org/repo'
 const bitbucketShirtcut = 'bitbucket:org/repo'

--- a/test/package/package.json
+++ b/test/package/package.json
@@ -180,5 +180,8 @@
       "development": "./src/index.js",
       "default": "./dist/index.js"
     }
+  },
+  "publishConfig": {
+    "exports": "./dist/index.js"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: `--exports` option was removed, same result can be achieved with `publishConfig`