### PR TITLE
Resolve configuration from `.clean-publish.json` file

### DIFF
--- a/get-config.js
+++ b/get-config.js
@@ -117,7 +117,7 @@ function configError(config) {
 
 export function getConfig() {
   const explorer = lilconfig('clean-publish', {
-    searchPlaces: ['package.json', '.clean-publish', '.clean-publish.js']
+    searchPlaces: ['package.json', '.clean-publish', '.clean-publish.js', '.clean-publish.json']
   })
   return explorer
     .search()


### PR DESCRIPTION
Explicitly specifying the `.json` extension for the configuration file is useful due to several reasons:
1. Better IDE support - IDE automatically does syntax highlight
2. Tooling support - no need for custom rule(s) to parse `.clean-publish.json` file:

    * Easier file globbing - `*.json` instead of `*.{json,clean-publish}` (when passing to eslint, prettier, etc.)
    * No custom rules in configurations. For instance, when using [eslint-plugin-json](https://github.com/azeemba/eslint-plugin-json)