### PR TITLE
Types for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $ yarn add clean-publish --dev
 - `temp-dir` - create temporary directory with given name.
 
 ```sh
-$ npx clean-publish --files file1.js file2.js --fields scripts name
+$ npx clean-publish --files "file1.js, file2.js" --fields "scripts, name"
 ```
 
 Also you are able to pass additional options to package manager:
@@ -104,7 +104,7 @@ $ npx clean-publish --package-manager pnpm -- --no-git-checks
 `clear-package-json` is additional tool to work only with `package.json` file.
 
 ```sh
-$ npx clear-package-json package.json -o package/package.json --fields scripts name
+$ npx clear-package-json package.json -o package/package.json --fields "scripts, name"
 # or
 $ npx clear-package-json package.json > package/package.json
 # or

--- a/clean-publish.js
+++ b/clean-publish.js
@@ -74,7 +74,7 @@ async function handleOptions() {
       options.cleanComments = true
       i += 1
     } else if (process.argv[i] === '--tag') {
-      options.tag = parseListArg(process.argv[i + 1])
+      options.tag = process.argv[i + 1]
       i += 1
     } else if (process.argv[i] === '--fields') {
       options.fields = parseListArg(process.argv[i + 1])

--- a/clean-publish.js
+++ b/clean-publish.js
@@ -70,7 +70,7 @@ async function handleOptions() {
     } else if (process.argv[i] === '--clean-docs') {
       options.cleanDocs = true
       i += 1
-    } else if (process.argv[i] === '--clean-commentd') {
+    } else if (process.argv[i] === '--clean-comments') {
       options.cleanComments = true
       i += 1
     } else if (process.argv[i] === '--tag') {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "repository": "shashkovdanil/clean-publish",
   "type": "module",
+  "types": "types.d.ts",
   "bin": {
     "clean-publish": "clean-publish.js",
     "clear-package-json": "clear-package-json.js"
@@ -22,6 +23,8 @@
   "scripts": {
     "lint": "eslint *.js test/*.js",
     "unit": "tsm node_modules/uvu/bin.js . 'test/[^/]+\\.test\\.js$'",
+    "schema": "ts-json-schema-generator --path types.d.ts --type Config --no-type-check --out schema.json",
+    "prepare": "yarn schema",
     "test": "yarn unit && yarn lint"
   },
   "dependencies": {
@@ -38,6 +41,7 @@
     "eslint-plugin-n": "^15.6.0",
     "eslint-plugin-prefer-let": "^3.0.1",
     "eslint-plugin-promise": "^6.1.1",
+    "ts-json-schema-generator": "^1.2.0",
     "tsm": "^2.3.0",
     "uvu": "^0.5.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ specifiers:
   fast-glob: ^3.2.12
   lilconfig: ^2.0.6
   micromatch: ^4.0.5
+  ts-json-schema-generator: ^1.2.0
   tsm: ^2.3.0
   uvu: ^0.5.6
 
@@ -29,6 +30,7 @@ devDependencies:
   eslint-plugin-n: 15.6.0_eslint@8.29.0
   eslint-plugin-prefer-let: 3.0.1
   eslint-plugin-promise: 6.1.1_eslint@8.29.0
+  ts-json-schema-generator: 1.2.0
   tsm: 2.3.0
   uvu: 0.5.6
 
@@ -126,6 +128,10 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.14.0
 
+  /@types/json-schema/7.0.11:
+    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
+    dev: true
+
   /@types/json5/0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
@@ -201,6 +207,12 @@ packages:
       concat-map: 0.0.1
     dev: true
 
+  /brace-expansion/2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.2
+    dev: true
+
   /braces/3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
@@ -243,6 +255,11 @@ packages:
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: true
+
+  /commander/9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
     dev: true
 
   /concat-map/0.0.1:
@@ -959,6 +976,17 @@ packages:
       path-is-absolute: 1.0.1
     dev: true
 
+  /glob/8.0.3:
+    resolution: {integrity: sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.2
+      once: 1.4.0
+    dev: true
+
   /globals/13.18.0:
     resolution: {integrity: sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==}
     engines: {node: '>=8'}
@@ -1175,6 +1203,12 @@ packages:
       minimist: 1.2.7
     dev: true
 
+  /json5/2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dev: true
+
   /kleur/4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
@@ -1230,6 +1264,13 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
+  /minimatch/5.1.2:
+    resolution: {integrity: sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimist/1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
     dev: true
@@ -1253,6 +1294,11 @@ packages:
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: true
+
+  /normalize-path/3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /object-inspect/1.12.2:
@@ -1422,6 +1468,11 @@ packages:
       is-regex: 1.1.4
     dev: true
 
+  /safe-stable-stringify/2.4.2:
+    resolution: {integrity: sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==}
+    engines: {node: '>=10'}
+    dev: true
+
   /semver/7.3.8:
     resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
     engines: {node: '>=10'}
@@ -1504,6 +1555,20 @@ packages:
       is-number: 7.0.0
     dev: false
 
+  /ts-json-schema-generator/1.2.0:
+    resolution: {integrity: sha512-tUMeO3ZvA12d3HHh7T/AK8W5hmUhDRNtqWRHSMN3ZRbUFt+UmV0oX8k1RK4SA+a+BKNHpmW2v06MS49e8Fi3Yg==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/json-schema': 7.0.11
+      commander: 9.5.0
+      glob: 8.0.3
+      json5: 2.2.3
+      normalize-path: 3.0.0
+      safe-stable-stringify: 2.4.2
+      typescript: 4.9.4
+    dev: true
+
   /tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
@@ -1531,6 +1596,12 @@ packages:
   /type-fest/0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+    dev: true
+
+  /typescript/4.9.4:
+    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
     dev: true
 
   /unbox-primitive/1.0.2:

--- a/schema.json
+++ b/schema.json
@@ -55,10 +55,7 @@
         },
         "tag": {
           "description": "Registers the package with the given tag.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+          "type": "string"
         },
         "tempDir": {
           "description": "Create temporary directory with given name.",

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,82 @@
+{
+  "$ref": "#/definitions/Config",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Config": {
+      "additionalProperties": false,
+      "properties": {
+        "access": {
+          "$ref": "#/definitions/PackageAccess",
+          "description": "Whether the npm registry publishes this package as a public package, or restricted."
+        },
+        "beforeScript": {
+          "description": "Run script on the to-release dir before npm publish.",
+          "type": "string"
+        },
+        "cleanComments": {
+          "default": false,
+          "description": "Clean inline comments from JS files.",
+          "type": "boolean"
+        },
+        "cleanDocs": {
+          "default": false,
+          "description": "Keep only main section of `README.md`",
+          "type": "boolean"
+        },
+        "dryRun": {
+          "description": "Reports the details of what would have been published.",
+          "type": "boolean"
+        },
+        "fields": {
+          "description": "List of fields in the `package.json` file that you want to delete before publishing.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "files": {
+          "description": "List of files that you want to delete before publishing (supports regex and glob patterns).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "packageManager": {
+          "$ref": "#/definitions/PackageManager",
+          "default": "npm",
+          "description": "Name of package manager to use."
+        },
+        "packageManagerOptions": {
+          "description": "Options which are directly passed into package manager during publish.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "tag": {
+          "description": "Registers the package with the given tag.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "tempDir": {
+          "description": "Create temporary directory with given name.",
+          "type": "string"
+        },
+        "withoutPublish": {
+          "default": false,
+          "description": "Clean project without `npm publish` (tmp directory will not be deleted automatically).",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "PackageAccess": {
+      "type": "string"
+    },
+    "PackageManager": {
+      "type": "string"
+    }
+  }
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -60,7 +60,7 @@ export interface Config {
     /**
      * Registers the package with the given tag.
      */
-    tag?: string[];
+    tag?: string;
 
     /**
      * Run script on the to-release dir before npm publish.

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,69 @@
+export type PackageAccess = 'public' | 'restricted' | string;
+
+export type PackageManager = 'npm' | 'pnpm' | 'yarn' | string;
+
+export interface Config {
+    /**
+     * Keep only main section of `README.md`
+     * @default false
+     */
+    cleanDocs?: boolean;
+
+    /**
+     * Clean inline comments from JS files.
+     * @default false
+     */
+    cleanComments?: boolean;
+
+    /**
+     * List of files that you want to delete before publishing (supports regex and glob patterns).
+     */
+    files?: Array<string | RegExp>;
+
+    /**
+     * List of fields in the `package.json` file that you want to delete before publishing.
+     */
+    fields?: string[];
+
+    /**
+     * Clean project without `npm publish` (tmp directory will not be deleted automatically).
+     * @default false
+     */
+    withoutPublish?: boolean;
+
+    /**
+     * Name of package manager to use.
+     * @default "npm"
+     */
+    packageManager?: PackageManager;
+
+    /**
+     * Whether the npm registry publishes this package as a public package, or restricted.
+     */
+    access?: PackageAccess;
+
+    /**
+     * Create temporary directory with given name.
+     */
+    tempDir?: string;
+
+    /**
+     * Options which are directly passed into package manager during publish.
+     */
+    packageManagerOptions?: string[];
+
+    /**
+     * Reports the details of what would have been published.
+     */
+    dryRun?: boolean;
+
+    /**
+     * Registers the package with the given tag.
+     */
+    tag?: string[];
+
+    /**
+     * Run script on the to-release dir before npm publish.
+     */
+    beforeScript?: string;
+}


### PR DESCRIPTION
## In this PR
1. Fixed a small typo in the [argument parsing function](https://github.com/shashkovdanil/clean-publish/blob/1e389335fb501d524137441a7fd055a8ad661b9d/clean-publish.js#L73): 
    ```diff
    -   } else if (process.argv[i] === '--clean-commentd') {
    +   } else if (process.argv[i] === '--clean-comments') {
    ```
3. Created types for the configuration. Types provide better documentation and autocompletion in IDEs.  Example usage:

    ```js
    // file `.clean-publish.js`

    /**
     * @type {import('clean-publish').Config}
     */
    const config = {
        /* Autocompletion works! */
    };

    module.exports = config;
    ```
4. Implemented JSON schema generation from TypeScript types. JSON schema generation is triggered in the `prepublish` script. Example usage:

    ```json
    {
        "$schema": "https://unpkg.com/clean-publish@latest/schema.json"
    }
    ```
## Some concerns

1. While writing typescript types, I discovered that the `tag` option is being parsed as an array, but used as a string. Parsing: https://github.com/shashkovdanil/clean-publish/blob/c2eed3bd69447b06468fde2850b5f964220f2934/clean-publish.js#L76-L78 Usage: https://github.com/shashkovdanil/clean-publish/blob/c2eed3bd69447b06468fde2850b5f964220f2934/core.js#L158-L163 I don't know, maybe the `spawn` function automatically flattens the arguments array?
2. If I correctly understood the [`parseListArg`](https://github.com/shashkovdanil/clean-publish/blob/c2eed3bd69447b06468fde2850b5f964220f2934/utils.js#L47) algorithm, it splits argument by commas. If so, then the documentation is incorrect: This line https://github.com/shashkovdanil/clean-publish/blob/c2eed3bd69447b06468fde2850b5f964220f2934/README.md?plain=1#L93 Must look like:
    
    ```sh
    $ npx clean-publish --files file1.js,file2.js --fields scripts,name 
    ```

    Or:

    ```sh
    $ npx clean-publish --files "file1.js, file2.js" --fields "scripts, name"
    ```