### PR TITLE
feat: add support for staged publishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ $ yarn add clean-publish --dev
 - `access` - whether the npm registry publishes this package as a public package, or restricted
 - `before-script` - run script on the to-release dir before `npm publish`
 - `temp-dir` - create temporary directory with given name.
+- `stage` - publish as a staged package (i.e. `npm stage publish`)
 
 ```sh
 $ npx clean-publish --files "file1.js, file2.js" --fields "scripts, name"

--- a/clean-publish.js
+++ b/clean-publish.js
@@ -37,6 +37,7 @@ const HELP =
   '  --before-script    Run script on the to-release dir before npm\n' +
   '                     publish\n' +
   '  --temp-dir         Create temporary directory with given name\n' +
+  '  --stage            Publish as a staged package (i.e. `npm stage publish`)\n' +
   '  --                 Pass next arguments as package manager options'
 
 const DEFAULT_OPTIONS = {
@@ -86,6 +87,8 @@ async function handleOptions() {
     } else if (process.argv[i] === '--temp-dir') {
       options.tempDir = process.argv[i + 1]
       i += 1
+    } else if (process.argv[i] === '--stage') {
+      options.stage = true
     } else if (process.argv[i] === '--') {
       options.packageManagerOptions = process.argv.slice(i + 1)
       break

--- a/core.js
+++ b/core.js
@@ -159,9 +159,10 @@ export async function copyFiles(tempDir, filter) {
 
 export async function publish(
   cwd,
-  { access, dryRun, packageManager, packageManagerOptions = [], tag }
+  { access, dryRun, packageManager, packageManagerOptions = [], tag, stage }
 ) {
-  const args = ['publish', ...packageManagerOptions]
+  const commands = stage ? ['stage', 'publish'] : ['publish']
+  const args = [...commands, ...packageManagerOptions]
   if (access) args.push('--access', access)
   if (tag) args.push('--tag', tag)
   if (dryRun) args.push('--dry-run')

--- a/schema.json
+++ b/schema.json
@@ -6,8 +6,8 @@
       "additionalProperties": false,
       "properties": {
         "access": {
-          "$ref": "#/definitions/PackageAccess",
-          "description": "Whether the npm registry publishes this package as a public package, or restricted."
+          "description": "Whether the npm registry publishes this package as a public package, or restricted.",
+          "type": "string"
         },
         "beforeScript": {
           "description": "Run script on the to-release dir before npm publish.",
@@ -50,9 +50,9 @@
           "type": "array"
         },
         "packageManager": {
-          "$ref": "#/definitions/PackageManager",
           "default": "npm",
-          "description": "Name of package manager to use."
+          "description": "Name of package manager to use.",
+          "type": "string"
         },
         "packageManagerOptions": {
           "description": "Options which are directly passed into package manager during publish.",
@@ -60,6 +60,11 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "stage": {
+          "default": false,
+          "description": "Publish as a staged package (i.e. `npm stage publish`).",
+          "type": "boolean"
         },
         "tag": {
           "description": "Registers the package with the given tag.",
@@ -76,12 +81,6 @@
         }
       },
       "type": "object"
-    },
-    "PackageAccess": {
-      "type": "string"
-    },
-    "PackageManager": {
-      "type": "string"
     }
   }
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -62,4 +62,10 @@ export interface Config {
    * Run script on the to-release dir before npm publish.
    */
   beforeScript?: string
+
+  /**
+   * Publish as a staged package (i.e. `npm stage publish`).
+   * @default false
+   */
+  stage?: boolean
 }


### PR DESCRIPTION
This adds a new `stage: boolean` flag which basically results in running
`npm stage publish` instead of `npm publish`.

Doing so will make use of npm's new staging feature where each published
package requires 2FA approval in npmjs.com or the npm CLI.
